### PR TITLE
Fix hydration error in NextJS 13

### DIFF
--- a/with-jotai/package.json
+++ b/with-jotai/package.json
@@ -9,10 +9,10 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "jotai": "^1.6.1",
-    "next": "12.1.0",
-    "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "jotai": "^1.9.0",
+    "next": "13.0.0",
+    "react": "18.0.0",
+    "react-dom": "18.0.0"
   },
   "devDependencies": {
     "@types/node": "^17.0.21",

--- a/with-jotai/pages/_app.js
+++ b/with-jotai/pages/_app.js
@@ -1,7 +1,8 @@
 import '../styles/globals.css'
+import { Provider } from 'Jotai'
 
 function MyApp({ Component, pageProps }) {
-  return <Component {...pageProps} />
+  return <Provider><Component {...pageProps} /></Provider>
 }
 
 export default MyApp


### PR DESCRIPTION
In NextJS 13 (with React 18) this code will create a hydration error because there will be a mismatch between the html returned by the server and the initial data in the props.

The fix is to wrap the App component in a jotai Provider as discussed [here](https://github.com/pmndrs/jotai/issues/1272) and [here](https://github.com/pmndrs/jotai/issues/1190).

This bug will not present itself in this code here since the API always returns the same data. (and this doesn't seem to cause an issue in NextJS 12)
But in a real world scenario when the api is not determinate this bug will arise.
This can be demonstrated in this repo by replacing the `getServerSideProps` with this code (And updating NextJS to 13):
```javascript
export async function getServerSideProps() {
  const resp = await fetch(
    "https://jherr-pokemon.s3.us-west-1.amazonaws.com/index.json"
  );
  const json = await resp.json();

  return {
    props: {
      initialPokemon: json.map((pokemon) => ({
        ...pokemon,
        name: pokemon.name + Math.random(),
      })),
    },
  };
}
```

The initial page will be rendered correctly, but when performing a refresh in the browser the issue will show itself..
(The rendered html will be stale but the props will update => hydration error)